### PR TITLE
Fix fish data migration

### DIFF
--- a/src/fish-persistent-data/devcontainer-feature.json
+++ b/src/fish-persistent-data/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Fish - persistent data",
     "id": "fish-persistent-data",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "A feature that provides persistent data for Fish shell",
     "mounts": [
         {

--- a/src/fish-persistent-data/onCreate.sh
+++ b/src/fish-persistent-data/onCreate.sh
@@ -6,13 +6,6 @@ user_local_dir=$HOME/.local
 user_share_dir=$user_local_dir/share
 user_fish_data_dir=$user_share_dir/fish
 
-# Migrate fish data from location used in versions 1.0.* to new location
-prev_fish_persistent_dir="$mount_point"/fish
-if [ -d "$prev_fish_persistent_dir" ]; then
-    echo "Migrating data from: $prev_fish_persistent_dir to $mount_point"
-    mv "$prev_fish_persistent_dir"/* "$mount_point"
-    rmdir "$prev_fish_persistent_dir"
-fi
 
 sudo() {
     if [ "$USER" = root ]; then
@@ -24,6 +17,14 @@ sudo() {
 
 # Prepare mounted volume permissions
 sudo chown "$USER":"$USER" "$mount_point"
+
+# Migrate fish data from location used in versions 1.0.* to new location
+prev_fish_persistent_dir="$mount_point"/fish
+if [ -d "$prev_fish_persistent_dir" ]; then
+    echo "Migrating data from: $prev_fish_persistent_dir to $mount_point"
+    mv "$prev_fish_persistent_dir"/* "$mount_point"
+    rmdir "$prev_fish_persistent_dir"
+fi
 
 # Rename theoretical old fish data directory
 if [ -d "$user_fish_data_dir" ]; then


### PR DESCRIPTION
The migration logic needs to be run after the chown command, so that the migration step can write to the destination directory.