### PR TITLE
poetry-persistent-cache can install before common-utils

### DIFF
--- a/src/poetry-persistent-cache/devcontainer-feature.json
+++ b/src/poetry-persistent-cache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Poetry - persistent cache",
     "id": "poetry-persistent-cache",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A feature that provides persistent cache for Poetry",
     "containerEnv": {
         "POETRY_CACHE_DIR": "/mnt/poetry-persistent-cache"
@@ -15,8 +15,5 @@
     ],
     "onCreateCommand": [
         "/usr/local/share/github-nikobockerman/devcontainer-features/poetry-persistent-cache/onCreate.sh"
-    ],
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
     ]
 }


### PR DESCRIPTION
Remove install ordering statement from poetry-persistent-cache that requires common-utils to be installed first. poetry-persistent-cache feature doesn't utilize common-utils even if it would be installed and it is therefore safe to install it already before common-utils.