### PR TITLE
Add debug output to fish-persistent-data onCreate

### DIFF
--- a/src/fish-persistent-data/devcontainer-feature.json
+++ b/src/fish-persistent-data/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Fish - persistent data",
     "id": "fish-persistent-data",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "A feature that provides persistent data for Fish shell",
     "mounts": [
         {

--- a/src/fish-persistent-data/install.sh
+++ b/src/fish-persistent-data/install.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+echo "Enabling debug output to investigate why fish-persistent-data fails to install properly on VSCode Recovery Containers"
+set -x
+
 content_base_dir=/usr/local/share/github-nikobockerman/devcontainer-features
 feature_content_dir=$content_base_dir/fish-persistent-data
 on_create_script=$feature_content_dir/onCreate.sh
@@ -9,3 +12,12 @@ on_create_script=$feature_content_dir/onCreate.sh
 mkdir -p "$feature_content_dir"
 cp onCreate.sh "$on_create_script"
 chmod +x "$on_create_script"
+
+env|sort || true
+umask || true
+ls -la /usr || true
+ls -la /usr/local || true
+ls -la /usr/local/share || true
+ls -la /usr/local/share/github-nikobockerman || true
+ls -la /usr/local/share/github-nikobockerman/devcontainer-features || true
+ls -la /usr/local/share/github-nikobockerman/devcontainer-features/fish-persistent-data || true

--- a/src/fish-persistent-data/onCreate.sh
+++ b/src/fish-persistent-data/onCreate.sh
@@ -1,11 +1,24 @@
 #!/bin/sh
 set -e
 
+# Debug settings
+echo "Enabling debug output to investigate why fish-persistent-data fails to install properly on VSCode Recovery Containers"
+set -x
+
 mount_point="/mnt/fish-persistent-data"
 user_local_dir=$HOME/.local
 user_share_dir=$user_local_dir/share
 user_fish_data_dir=$user_share_dir/fish
 
+env|sort || true
+mount || true
+umask || true
+ls -la /mnt/ || true
+ls -la "$mount_point" || true
+ls -la "$HOME" || true
+ls -la "$user_local_dir" || true
+ls -la "$user_share_dir" || true
+ls -la "$user_fish_data_dir" || true
 
 sudo() {
     if [ "$USER" = root ]; then
@@ -22,7 +35,9 @@ sudo chown "$USER":"$USER" "$mount_point"
 prev_fish_persistent_dir="$mount_point"/fish
 if [ -d "$prev_fish_persistent_dir" ]; then
     echo "Migrating data from: $prev_fish_persistent_dir to $mount_point"
+    ls -la "$prev_fish_persistent_dir" || true
     mv "$prev_fish_persistent_dir"/* "$mount_point"
+    ls -la "$mount_point" || true
     rmdir "$prev_fish_persistent_dir"
 fi
 


### PR DESCRIPTION
fish-persistent-data feature fails to execute the onCreate.sh script when the feature is enabled as user defaultFeatures and a recovery container is created. This is a special environment and cumbersome to debug, but this version hopefully prints out enough information to provide a clue at the exact problem and how it should be handled without failure.