### PR TITLE
fix: add sudo to chown commands to handle permission errors

### DIFF
--- a/src/fish-persistent-data/onCreate.sh
+++ b/src/fish-persistent-data/onCreate.sh
@@ -33,6 +33,6 @@ fi
 
 # Create new fish data directory as symlink to the mounted volume
 mkdir -p "$user_share_dir"
-chown "$USER":"$USER" -R "$user_local_dir"
+sudo chown "$USER":"$USER" -R "$user_local_dir"
 ln -s "$mount_point" "$user_fish_data_dir"
-chown -h "$USER":"$USER" "$user_fish_data_dir"
+sudo chown -h "$USER":"$USER" "$user_fish_data_dir"


### PR DESCRIPTION
## Summary
- Fixes permission errors when other devcontainer features create files in `~/.local` before fish-persistent-data runs
- Adds `sudo` to both `chown` commands in `onCreate.sh` to ensure proper ownership changes

## Problem
When other devcontainer features (like Python tools) run before `fish-persistent-data`, they create files in `/home/vscode/.local/` as root. The current script then fails with:
```
chown: changing ownership of '/home/vscode/.local/share/man/man1/bandit.1': Operation not permitted
```

## Root Cause
Two `chown` commands in `onCreate.sh` try to change ownership without elevated privileges:
- Line 36: `chown "$USER":"$USER" -R "$user_local_dir"`
- Line 38: `chown -h "$USER":"$USER" "$user_fish_data_dir"`

## Solution
Both commands now use the existing `sudo()` function to handle ownership changes properly:
- Line 36: `sudo chown "$USER":"$USER" -R "$user_local_dir"`
- Line 38: `sudo chown -h "$USER":"$USER" "$user_fish_data_dir"`

## Test plan
- [x] Verified the script already has a proper `sudo()` function that handles root/non-root users
- [x] Confirmed both `chown` operations now use consistent permission handling
- [ ] Test with a devcontainer configuration that includes Python features before fish-persistent-data

Fixes #162

🤖 Generated with [Claude Code](https://claude.ai/code)