### PR TITLE
Remove renovate config check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,6 @@ jobs:
     with:
       task: check:prettier
 
-  check-renovate-config:
-    needs: mise-cache
-    uses: ./.github/workflows/mise-task.yaml
-    with:
-      task: check:renovateconfig
-
   check-shellcheck:
     needs: mise-cache
     uses: ./.github/workflows/mise-task.yaml
@@ -49,7 +43,6 @@ jobs:
     needs:
       - check-feature-configs
       - check-prettier
-      - check-renovate-config
       - check-shellcheck
       - test-features
     runs-on: ubuntu-latest

--- a/mise.toml
+++ b/mise.toml
@@ -6,16 +6,11 @@ shellcheck = "0.11.0"
 [tasks.check]
 depends = [
     "check:prettier",
-    "check:renovateconfig",
     "check:shellcheck"
 ]
 
 [tasks."check:prettier"]
 run = "prettier --check ."
-
-[tasks."check:renovateconfig"]
-run = "renovate-config-validator --strict"
-tools."npm:renovate" = "latest"
 
 [tasks."check:shellcheck"]
 run = "shellcheck $(git ls-files | grep '.sh$')"


### PR DESCRIPTION
Renovate version used in check is newest version but the hosted renovate runner may use some older version. And the result may be that the newest version reports a need for config migration but the hosted version won't yet support that new config.