### PR TITLE
Reconfigure renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     "config:best-practices",
     ":pinAllExceptPeerDependencies",
     "customManagers:githubActionsVersions",
+    "schedule:monthly",
     "security:minimumReleaseAgeNpm",
   ],
 
@@ -17,8 +18,6 @@
     {
       description: "Mise package settings",
       matchPackageNames: ["jdx/mise"],
-
-      automerge: true,
       minimumReleaseAge: "1 day", // 1 day delay to avoid errors installing very fresh version
     },
   ],


### PR DESCRIPTION
- Set schedule for new updates to be once per month
  - No dependencies are needed for released packages and this reduces workload required to keep development dependencies up-to-date
- Disable automerge for mise -> all update merges are manual
  - Updates are much more rare now so no need to merge even mise updates automatically